### PR TITLE
問題回答時に問題数を表示させました

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -14,6 +14,11 @@ class QuestionsController < ApplicationController
   def show
     @challenger = @quiz.challengers.find(params[:challenger_id])
     @question = @quiz.questions.find(params[:id])
+    @questions_count = @quiz.questions.all.count
+    if flash.blank?
+      @challenger.question_count += 1
+      @challenger.save
+    end
   end
 
   def create

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -1,4 +1,5 @@
 h2 #{@quiz.creator_name}王
 br
+h5 #{@challenger.question_count} / #{@questions_count}
 
 = render "questions/judgement"

--- a/db/migrate/20210918034442_add_question_count_to_challengers.rb
+++ b/db/migrate/20210918034442_add_question_count_to_challengers.rb
@@ -1,0 +1,5 @@
+class AddQuestionCountToChallengers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :challengers, :question_count, :integer, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_071705) do
+ActiveRecord::Schema.define(version: 2021_09_18_034442) do
 
   create_table "challengers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2021_07_30_071705) do
     t.bigint "quiz_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "question_count", default: 0, null: false
     t.index ["quiz_id"], name: "index_challengers_on_quiz_id"
   end
 


### PR DESCRIPTION
## 概要
ユーザーの声を参考に問題の回答時に、今何問目かがわかるように実装しました。
また、これを実装するために、challengersテーブルにquestion_countカラムを追加しました。

## 確認事項
- 問題回答時に、問題の合計数と今何問目であるかが表示されていること
- challengersテーブルにquestion_countカラムが追加されていること