### PR TITLE
問題が0問でも作成されてしまうバグを修正

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -17,7 +17,7 @@ class QuizzesController < ApplicationController
   def create
     @quiz = Quiz.new(quiz_params)
     if @quiz.save
-      render quiz_questions_path(@quiz.id)
+      redirect_to quiz_questions_path(@quiz.id)
     else
       render 'new'
     end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -5,6 +5,9 @@ class QuizzesController < ApplicationController
   def show
     @quiz = Quiz.find(params[:id])
     @questions = @quiz.questions.all.includes(:quiz)
+    if @questions.blank?
+      redirect_to quiz_questions_path(@quiz.id)
+    end
   end
 
   def new
@@ -14,7 +17,7 @@ class QuizzesController < ApplicationController
   def create
     @quiz = Quiz.new(quiz_params)
     if @quiz.save
-      redirect_to quiz_questions_path(@quiz.id)
+      render quiz_questions_path(@quiz.id)
     else
       render 'new'
     end

--- a/app/views/questions/_set_correct_answer.html.slim
+++ b/app/views/questions/_set_correct_answer.html.slim
@@ -10,3 +10,11 @@
           = button_to choice.body, set_correct_answer_quiz_question_choice_path(@quiz.id, question.id, choice.id), class: 'choice-radius btn btn-outline-secondary', remote: true
       = link_to '削除', quiz_question_path(@quiz.id, question.id), method: :delete, data: {confirm: "本当に削除しますか？"}, class: 'text-secondary', remote: true
     br
+
+  - if @questions.present?
+    = link_to '作成する', quiz_path(@quiz), class: 'radius btn btn-secondary btn-sm'
+    br
+    br
+  - else
+    p 問題を追加してみよう！
+    = link_to 'テンプレートを使う', quiz_questions_path(@quiz.id), class: 'text-secondary btn-sm'

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -5,11 +5,4 @@ br
 = render partial: "questions/set_correct_answer", locals: {question: @questions}
 br
 
-= link_to '作成する', quiz_path(@quiz), class: 'radius btn btn-secondary btn-sm'
-br
-br
-br
-br
-br
-
 = render partial: "questions/question_form", locals: {question: @question}


### PR DESCRIPTION
## 概要
問題が0問でも作成されてしまうバグを修正しました。

## 確認事項
- 問題が存在している時
  - 作成ボタンが表示されていること
  　
- 問題を全て削除した時
  - 作成ボタンが表示されていないこと
  - 「問題を追加してみよう！」と表示されていること
  - 「テンプレートを使う」ボタンが表示され、ボタンを押すと問題が追加されること