### PR TITLE
問題回答時のユーザーストレスを解消する #28

### DIFF
--- a/app/controllers/challengers_controller.rb
+++ b/app/controllers/challengers_controller.rb
@@ -4,6 +4,7 @@ class ChallengersController < ApplicationController
 
   def show
     @challenger = @quiz.challengers.find(params[:id])
+    @questions = @quiz.questions.all
     @questions_count = @quiz.questions.count
     @challengers_ranking = @quiz.challengers.order(score: :DESC).limit(10)
   end

--- a/app/controllers/choices_controller.rb
+++ b/app/controllers/choices_controller.rb
@@ -16,14 +16,16 @@ class ChoicesController < ApplicationController
   def judgement
     challenger = @quiz.challengers.find(params[:challenger_id])
     choice = @question.choices.find(params[:id])
+    choice.select_answer = true
+    choice.save
     if choice.correct_answer == true
       challenger.score += 1
       challenger.save
-      flash[:notice] = "正解！！"
-      redirect_to quiz_challenger_question_path(@quiz.id, challenger.id, @question.id)
+    end
+    if @question.next(@quiz).present?
+      redirect_to quiz_challenger_question_path(@quiz.id, challenger.id, @question.next(@quiz))
     else
-      flash[:notice] = "ざんねん！"
-      redirect_to quiz_challenger_question_path(@quiz.id, challenger.id, @question.id)
+      redirect_to quiz_challenger_path(@quiz.id, challenger.id)
     end
   end
 
@@ -32,9 +34,5 @@ class ChoicesController < ApplicationController
   def set_question
     @quiz = Quiz.find(params[:quiz_id])
     @question = @quiz.questions.find(params[:question_id])
-  end
-
-  def correct_answer_params
-    params.require(:question).permit(choices_attributes:[:id, :correct_answer])
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -15,6 +15,11 @@ class QuestionsController < ApplicationController
     @challenger = @quiz.challengers.find(params[:challenger_id])
     @question = @quiz.questions.find(params[:id])
     @questions_count = @quiz.questions.all.count
+    choices = @question.choices.all
+    choices.each do |choice|
+      choice.select_answer = false
+      choice.save
+    end
     if flash.blank?
       @challenger.question_count += 1
       @challenger.save

--- a/app/views/challengers/show.html.slim
+++ b/app/views/challengers/show.html.slim
@@ -8,6 +8,8 @@ br
 
 = render "challengers/ranking"
 
+= render "questions/check_the_answer"
+
 = render "challengers/share_link"
 
 = link_to '問題を作成する', root_path, class: 'radius btn btn-secondary'

--- a/app/views/choices/judgement.js.erb
+++ b/app/views/choices/judgement.js.erb
@@ -1,0 +1,1 @@
+$('#judgement_ajax').html("<%= j(render partial: "questions/judgement", locals: {question: @questions}) %>");

--- a/app/views/questions/_check_the_answer.html.slim
+++ b/app/views/questions/_check_the_answer.html.slim
@@ -1,0 +1,24 @@
+- @questions.each do |question|
+  .question-box
+    .box-title
+      p = question.body
+    - question.choices.each do |choice|
+      - if choice.correct_answer == true && choice.select_answer == true
+        = button_to "🎉 " + choice.body + " 🎉", quiz_path(@quiz.id), disabled: true, class: 'choice-radius btn btn-success'
+      - elsif choice.correct_answer == true && choice.select_answer == false
+        = button_to choice.body, quiz_path(@quiz.id), disabled: true, class: 'choice-radius btn btn-outline-success'
+      - elsif choice.correct_answer == false && choice.select_answer == true
+        = button_to choice.body, quiz_path(@quiz.id), disabled: true, class: 'choice-radius btn btn-danger'
+      - else
+        = button_to choice.body, quiz_path(@quiz.id), disabled: true, class: 'choice-radius btn btn-outline-danger'
+
+    - question.choices.each do |choice|
+      - if choice.correct_answer == true && choice.select_answer == true
+        .text-secondary
+          p 正解！！
+      - elsif choice.correct_answer == false && choice.select_answer == true
+        .text-secondary
+          p 不正解
+  br        
+br
+br

--- a/app/views/questions/_judgement.html.slim
+++ b/app/views/questions/_judgement.html.slim
@@ -3,25 +3,6 @@
     .box-title
       p = @question.body
     - @question.choices.each do |choice|
-      - if flash.present?
-        = button_to choice.body, judgement_quiz_challenger_question_choice_path(@quiz.id, @challenger.id, @question.id, choice.id), disabled: true, class: 'choice-radius btn btn-outline-secondary'
-        - if choice.correct_answer == true
-          .text-success
-            p = '○'
-        - else
-          .text-danger
-            p = '×'  
-      - else
-        = button_to choice.body, judgement_quiz_challenger_question_choice_path(@quiz.id, @challenger.id, @question.id, choice.id), class: 'choice-radius btn btn-outline-secondary'
-
-    .notifications
-      - flash.each do |key, value|
-        = content_tag(:div, value, class: key)
+      = button_to choice.body, judgement_quiz_challenger_question_choice_path(@quiz.id, @challenger.id, @question.id, choice.id), class: 'choice-radius btn btn-outline-secondary', remote: true
   br
-  br
-  - if @question.next(@quiz).present? && flash.present?
-    = link_to "NEXT",quiz_challenger_question_path(@quiz.id, @challenger.id, @question.next(@quiz)), class: 'radius btn-secondary btn-sm'
-
-  -if @question.next(@quiz).blank? && flash.present?
-    = link_to "結果",quiz_challenger_path(@quiz.id, @challenger.id), class: 'radius btn btn-secondary btn-sm'
   br

--- a/app/views/questions/show.js.erb
+++ b/app/views/questions/show.js.erb
@@ -1,2 +1,0 @@
-$('#judgement_ajax').html("<%= j(render partial: "questions/judgement", locals: {question: @questions}) %>");
-$('.js-form')[0].reset();

--- a/db/migrate/20210918151924_add_select_answer_to_choices.rb
+++ b/db/migrate/20210918151924_add_select_answer_to_choices.rb
@@ -1,0 +1,5 @@
+class AddSelectAnswerToChoices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :choices, :select_answer, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_18_034442) do
+ActiveRecord::Schema.define(version: 2021_09_18_151924) do
 
   create_table "challengers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2021_09_18_034442) do
     t.bigint "question_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "select_answer", default: false, null: false
     t.index ["question_id"], name: "index_choices_on_question_id"
   end
 


### PR DESCRIPTION
## 概要
選択→答え合わせ→選択→答え合わせで遷移が多く、ユーザーに対するストレスがかかっていたので、最後に一気に答え合わせ + 非同期でサクサク表示させるよう修正しました。

## 確認事項
- 回答を選択すると非同期で次の問題に移ること
- 最後の問題を回答すると回答結果ページに遷移し、答え合わせが表示されていること
