### PR TITLE
問題作成時に選択肢を選択しなくても作成できてしまう仕様を修正

### DIFF
--- a/app/controllers/choices_controller.rb
+++ b/app/controllers/choices_controller.rb
@@ -11,6 +11,8 @@ class ChoicesController < ApplicationController
     @choice.correct_answer = true
     @choice.save
     @questions = @quiz.questions.all.includes(:quiz)
+    @questions_count = @questions.count
+    @complete_questions_count = @questions.joins(:choices).where(choices: {correct_answer: true}).count
   end
 
   def judgement

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -33,6 +33,8 @@ class QuestionsController < ApplicationController
     @question = @quiz.questions.new(question_params)
     if @question.save
       @questions = @quiz.questions.all.includes(:quiz)
+      @questions_count = @questions.count
+      @complete_questions_count = @questions.joins(:choices).where(choices: {correct_answer: true}).count
     else
       @questions = @quiz.questions.all.includes(:quiz)
       render "index"

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -6,8 +6,11 @@ class QuestionsController < ApplicationController
     @questions = @quiz.questions.all.includes(:quiz)
     @question = Question.new
     @question.choices.build
+    @questions_count = @questions.count
+    @complete_questions_count = @questions.joins(:choices).where(choices: {correct_answer: true}).count
     if @questions.blank?
       default_questions
+      @questions_count = @quiz.questions.all.count
     end
   end
 
@@ -40,6 +43,8 @@ class QuestionsController < ApplicationController
     question = @quiz.questions.find(params[:id])
     @questions = @quiz.questions.all.includes(:quiz)
     question.destroy!
+    @questions_count = @quiz.questions.all.count
+    @complete_questions_count = @questions.joins(:choices).where(choices: {correct_answer: true}).count
   end
 
   private

--- a/app/views/questions/_set_correct_answer.html.slim
+++ b/app/views/questions/_set_correct_answer.html.slim
@@ -11,10 +11,12 @@
       = link_to '削除', quiz_question_path(@quiz.id, question.id), method: :delete, data: {confirm: "本当に削除しますか？"}, class: 'text-secondary', remote: true
     br
 
-  - if @questions.present?
+  - if @questions.present? && @questions_count == @complete_questions_count
     = link_to '作成する', quiz_path(@quiz), class: 'radius btn btn-secondary btn-sm'
     br
     br
+  - elsif @questions.present? && @questions_count != @complete_questions_count
+    p 回答を選択してください
   - else
     p 問題を追加してみよう！
     = link_to 'テンプレートを使う', quiz_questions_path(@quiz.id), class: 'text-secondary btn-sm'

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,17 +1,17 @@
 example_id                              | status | run_time        |
 --------------------------------------- | ------ | --------------- |
-./spec/models/challenger_spec.rb[1:1:1] | passed | 0.00116 seconds |
-./spec/models/challenger_spec.rb[1:1:2] | passed | 0.01244 seconds |
-./spec/models/challenger_spec.rb[1:1:3] | passed | 0.00199 seconds |
-./spec/models/challenger_spec.rb[1:1:4] | passed | 0.00188 seconds |
-./spec/models/choice_spec.rb[1:1:1]     | passed | 0.0018 seconds  |
-./spec/models/choice_spec.rb[1:1:2]     | passed | 0.00299 seconds |
-./spec/models/choice_spec.rb[1:1:3]     | passed | 0.00294 seconds |
-./spec/models/choice_spec.rb[1:1:4]     | passed | 0.00256 seconds |
-./spec/models/question_spec.rb[1:1:1]   | passed | 0.01796 seconds |
-./spec/models/question_spec.rb[1:1:2]   | passed | 0.27738 seconds |
-./spec/models/question_spec.rb[1:1:3]   | passed | 0.00277 seconds |
-./spec/models/question_spec.rb[1:1:4]   | passed | 0.00252 seconds |
-./spec/models/quiz_spec.rb[1:1:1]       | passed | 0.00163 seconds |
-./spec/models/quiz_spec.rb[1:1:2]       | passed | 0.00239 seconds |
-./spec/models/quiz_spec.rb[1:1:3]       | passed | 0.00274 seconds |
+./spec/models/challenger_spec.rb[1:1:1] | passed | 0.00115 seconds |
+./spec/models/challenger_spec.rb[1:1:2] | passed | 0.00162 seconds |
+./spec/models/challenger_spec.rb[1:1:3] | passed | 0.00203 seconds |
+./spec/models/challenger_spec.rb[1:1:4] | passed | 0.22041 seconds |
+./spec/models/choice_spec.rb[1:1:1]     | passed | 0.01707 seconds |
+./spec/models/choice_spec.rb[1:1:2]     | passed | 0.00196 seconds |
+./spec/models/choice_spec.rb[1:1:3]     | passed | 0.00167 seconds |
+./spec/models/choice_spec.rb[1:1:4]     | passed | 0.00187 seconds |
+./spec/models/question_spec.rb[1:1:1]   | passed | 0.00149 seconds |
+./spec/models/question_spec.rb[1:1:2]   | passed | 0.00553 seconds |
+./spec/models/question_spec.rb[1:1:3]   | passed | 0.00224 seconds |
+./spec/models/question_spec.rb[1:1:4]   | passed | 0.00318 seconds |
+./spec/models/quiz_spec.rb[1:1:1]       | passed | 0.00084 seconds |
+./spec/models/quiz_spec.rb[1:1:2]       | passed | 0.00174 seconds |
+./spec/models/quiz_spec.rb[1:1:3]       | passed | 0.00158 seconds |


### PR DESCRIPTION
## 概要
問題作成時に選択肢を選択しなくても作成できてしまう仕様を修正しました。

## 確認方法
以下の項目が表示されること
- 問題が存在し、全ての回答が選択されている時 → 「作成ボタン」
- 問題が存在し、回答が選択されていない問題がある時 → 「回答を選択してください」
- 問題が存在しない時 → 「問題を追加してみよう！」「テンプレートを使う(リンク)」