### PR TITLE
トップページの「ニックネーム」を「クイズタイトル」に変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -113,9 +113,20 @@ body {
     margin: 3px 2px;
     border-radius:20px;
     border-width: 1px;
+    border: none;
 }
 
 .choice-form:focus {
     text-align: center;
     outline: none;
+}
+
+.title-box {
+    padding: 0px 0px 0px 14px;
+    display: flex;
+}
+
+.ou {
+    margin-top: 6px;
+    margin-left: 2px;
 }

--- a/app/views/quizzes/new.html.slim
+++ b/app/views/quizzes/new.html.slim
@@ -10,8 +10,10 @@ br
 = form_with model: @quiz, local: true do |f|
   = render "shared/errors.full_messages", object: f.object
   .form-group
-    = f.label :creator_name, "ニックネーム"
-    = f.text_field :creator_name, class: 'radius form-control'
+    = f.label :creator_name, "クイズタイトル"
+    .title-box
+      = f.text_field :creator_name, class: 'radius form-control'
+      = f.label :creator_name, "王", class: 'ou'
   br
   = f.submit '問題を作成', class: 'radius btn btn-success'
 br

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@ ja:
   activerecord:
     attributes:
       quiz:
-        creator_name: "ニックネーム"
+        creator_name: "クイズタイトル"
       question:
         body: "問題"
       choices:


### PR DESCRIPTION
## 概要
トップページのフォームを「ニックネーム」から「クイズタイトル」に変更しました。
　

## 確認事項
- フォームのラベルが「クイズタイトル」になっていること
- フォームの後ろに「王」がついていること
- 以下のエラーメッセージが表示されること
  - 「クイズタイトルを入力してください」
  - 「クイズタイトルは12文字以内で入力してください」
