### PR TITLE
作成した問題を他の人が編集できないようにする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,9 +1,10 @@
 class QuestionsController < ApplicationController
   before_action :set_quiz_questions
-  before_action :set_questions_count
-  before_action :set_complete_questions_count, expect: [:show]
+  before_action :set_questions_count, expect: [:destroy]
+  before_action :set_complete_questions_count, expect: [:show, :destroy]
 
   def index
+    redirect_to root_path if quiz_already_created?
     @question = Question.new
     @question.choices.build
     return if @questions.present?
@@ -27,6 +28,8 @@ class QuestionsController < ApplicationController
   def destroy
     question = @quiz.questions.find(params[:id])
     question.destroy!
+    set_questions_count
+    set_complete_questions_count
   end
 
   private
@@ -57,5 +60,9 @@ class QuestionsController < ApplicationController
     choices = @question.choices.all
     choices.select_answers_false(choices)
     @challenger.add_question_count(@challenger)
+  end
+
+  def quiz_already_created?
+    @questions.present? && @questions_count == @complete_questions_count
   end
 end

--- a/app/views/questions/_set_correct_answer.html.slim
+++ b/app/views/questions/_set_correct_answer.html.slim
@@ -7,7 +7,7 @@
         - if choice.correct_answer == true
           = button_to choice.body, quiz_question_choice_set_correct_answers_path(quiz.id, question.id, choice.id), class: 'choice-radius btn btn-celect', remote: true
         - else
-          = button_to choice.body, quiz_question_choice_set_correct_answers_path(quiz, question.id, choice.id), class: 'choice-radius btn btn-outline-secondary', remote: true
+          = button_to choice.body, quiz_question_choice_set_correct_answers_path(quiz.id, question.id, choice.id), class: 'choice-radius btn btn-outline-secondary', remote: true
       = link_to '削除', quiz_question_path(quiz.id, question.id), method: :delete, data: {confirm: "本当に削除しますか？"}, class: 'text-secondary', remote: true
     br
 


### PR DESCRIPTION
## 概要
現状、問題作成画面のURLでアクセスすることで、誰でも問題を編集することができてしまう。
すでに「〇〇王」が作成されている場合、URLでアクセスしてもトップページへリダイレクトされるよう実装しました。

## 確認事項
- すでに「〇〇王」が作成されている場合、URLでアクセスしてもトップページへリダイレクトされること